### PR TITLE
Shift feature fix and add vertical moves possible

### DIFF
--- a/visplot.py
+++ b/visplot.py
@@ -181,6 +181,23 @@ class plot:
     def on_mouse_press(self, event):
         self._init_pos = event.pos
 
+    def restore_offset(self, curves: Optional[int] = None):
+        """
+        Replace the curves to their initial place, i.e. removes the cumulative offset previously
+        applied on them.
+        :param curves: The curves' number to reset the offset. If None, uses the selected curves. If
+        no curves are selected, restores all the offsets for all curves.
+        """
+        if curves is None:
+            curves = self.selected_lines
+            if len(curves) == 0:
+                curves = list(self.lines_offset.keys())
+        for line_no in curves:
+            if line_no in self.lines_offset:
+                offset = self.lines_offset[line_no]
+                self.apply_offset(line_no, (-offset[0], -offset[1]))
+                del self.lines_offset[line_no]
+
     def apply_offset(self, curve_no: int, offset: Tuple[float, float]):
         """
         Moves the curve for a given (x, y) offset.

--- a/visplot.py
+++ b/visplot.py
@@ -119,6 +119,8 @@ class plot:
         self.line = scene.Line(pos=xy_curves, color=self.colors, parent=self.view.scene, connect=connect)
 
         self.selected_lines = [] 
+        # To store the lines offsets applied with the "shift"
+        self.lines_offset = {}
         self.hl_labels = []
         self.hl_colorset = cycle(color.get_colormap(clrmap)[np.linspace(0.0, 1.0, self.MAX_HL)])
 
@@ -182,12 +184,15 @@ class plot:
     def apply_offset(self, curve_no: int, offset: Tuple[float, float]):
         """
         Moves the curve for a given (x, y) offset.
+        The cumulative offset is stored in internal dictionary in order to be possibly restored.
         :param curve_no: The curve identifier to apply the offset
         :param offset: The displacement to apply to the curve.
         """
         self.line.pos[curve_no][:,0] += offset[0]
         self.line.pos[curve_no][:,1] += offset[1]
         self.line.set_data(pos=self.line.pos)
+        curve_offset = self.lines_offset.get(curve_no, [0.0, 0.0])
+        self.lines_offset[curve_no] = [offset[0] + curve_offset[0], offset[1] + curve_offset[1]]
 
     def on_mouse_move(self,event):
         if self.shift_pressed == True:

--- a/visplot.py
+++ b/visplot.py
@@ -179,6 +179,16 @@ class plot:
     def on_mouse_press(self, event):
         self._init_pos = event.pos
 
+    def apply_offset(self, curve_no: int, offset: Tuple[float, float]):
+        """
+        Moves the curve for a given (x, y) offset.
+        :param curve_no: The curve identifier to apply the offset
+        :param offset: The displacement to apply to the curve.
+        """
+        self.line.pos[curve_no][:,0] += offset[0]
+        self.line.pos[curve_no][:,1] += offset[1]
+        self.line.set_data(pos=self.line.pos)
+
     def on_mouse_move(self,event):
         if self.shift_pressed == True:
             if len(self.selected_lines) > 0:
@@ -189,8 +199,8 @@ class plot:
                 x,y,_,_ = tr.map(event.pos)
                 init_x,init_y,_,_ = tr.map(self._init_pos)
                 delta_x = int(x - init_x)
-                for l in self.selected_lines:
-                    self.line.pos[l][:,1] = np.roll(self.line.pos[l][:,1],delta_x)
+                for curve_no in self.selected_lines:
+                    self.apply_offset(curve_no, (delta_x, 0.0))
                 self._init_pos = event.pos
                 self.canvas.update()
 

--- a/visplot.py
+++ b/visplot.py
@@ -48,6 +48,8 @@ class plot:
 
         self.ctrl_pressed = False 
         self.shift_pressed = False 
+        self.alt_pressed = False
+
         self.canvas.connect(self.on_key_press)
         self.canvas.connect(self.on_key_release)
         self.canvas.connect(self.on_mouse_press)
@@ -171,12 +173,16 @@ class plot:
         if event.key == 'Shift':
             self.shift_pressed = True
             self._init_pos = None
+        if event.key == 'Alt':
+            self.alt_pressed = True
 
     def on_key_release(self, event):
         if event.key == 'Control':
             self.ctrl_pressed = False 
         if event.key == 'Shift':
             self.shift_pressed = False 
+        if event.key == 'Alt':
+            self.alt_pressed = False
 
     def on_mouse_press(self, event):
         self._init_pos = event.pos
@@ -212,7 +218,7 @@ class plot:
         self.lines_offset[curve_no] = [offset[0] + curve_offset[0], offset[1] + curve_offset[1]]
 
     def on_mouse_move(self,event):
-        if self.shift_pressed == True:
+        if self.shift_pressed:
             if len(self.selected_lines) > 0:
                 if self._init_pos is None:
                     self._init_pos = event.pos
@@ -220,9 +226,11 @@ class plot:
                 tr = self.canvas.scene.node_transform(self.view.scene)
                 x,y,_,_ = tr.map(event.pos)
                 init_x,init_y,_,_ = tr.map(self._init_pos)
-                delta_x = int(x - init_x)
+                delta_x = x - init_x
+                delta_y = y - init_y
                 for curve_no in self.selected_lines:
-                    self.apply_offset(curve_no, (delta_x, 0.0))
+                    self.apply_offset(curve_no,
+                                      (0.0, delta_y) if self.alt_pressed else (delta_x, 0.0))
                 self._init_pos = event.pos
                 self.canvas.update()
 


### PR DESCRIPTION
- Replace the 'roll' of curves by x-y offset displacement
- y displacement is possible by hitting SHIFT+ALT keys simultaneously
- Fixes the refresh of the view when offsetting curve (#7)
- No click is needed for offsetting
- Restore of offsets is possible by calling plot.restore_offset function
