### PR TITLE
fix: allow np.arrays of arrays to be drawn again

### DIFF
--- a/visplot.py
+++ b/visplot.py
@@ -94,10 +94,11 @@ class plot:
         labels: Optional[list[str]] = None,
         clrmap: str = "husl",
     ):
-        if not isinstance(curves, list) or (
-            isinstance(curves, np.ndarray) and curves.ndim == 1
-        ):
-            # assume single curve
+        # cases where a single array needs to be drawn
+        if isinstance(curves, list):
+            if not (isinstance(curves[0], list) or isinstance(curves[0], np.ndarray)):
+                curves = [curves]
+        elif isinstance(curves, np.ndarray) and curves.ndim == 1:
             curves = [curves]
 
         # keep an array of lengths


### PR DESCRIPTION
some changes in the check on single-trace arrays led 
`plot(np.array([some_array, other_array]))` 
to be  `not isinstance(curves, list)` and transformed into an array of array of arrays, which then fails to display.

This PR introduces a different check for that part.

Thanks for the latest additions btw!